### PR TITLE
Add weekly and monthly rain charts with long-term sensors

### DIFF
--- a/rain-gauge/extended-configuration.yaml
+++ b/rain-gauge/extended-configuration.yaml
@@ -1,0 +1,95 @@
+---
+# Additional sensors for long-term rain statistics.
+
+sensor:
+  - platform: history_stats
+    unique_id: rain_gauge_flips_on_week
+    name: "Rain Gauge flips/on [week]"
+    entity_id: binary_sensor.rain_gauge
+    state: "on"
+    type: count
+    start: >
+      {{ now().replace(hour=0, minute=0, second=0)
+         - timedelta(days=now().weekday()) }}
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_off_week
+    name: "Rain Gauge flips/off [week]"
+    entity_id: binary_sensor.rain_gauge
+    state: "off"
+    type: count
+    start: >
+      {{ now().replace(hour=0, minute=0, second=0)
+         - timedelta(days=now().weekday()) }}
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_on_month
+    name: "Rain Gauge flips/on [month]"
+    entity_id: binary_sensor.rain_gauge
+    state: "on"
+    type: count
+    start: "{{ now().replace(day=1, hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_off_month
+    name: "Rain Gauge flips/off [month]"
+    entity_id: binary_sensor.rain_gauge
+    state: "off"
+    type: count
+    start: "{{ now().replace(day=1, hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_on_year
+    name: "Rain Gauge flips/on [year]"
+    entity_id: binary_sensor.rain_gauge
+    state: "on"
+    type: count
+    start: "{{ now().replace(month=1, day=1, hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_off_year
+    name: "Rain Gauge flips/off [year]"
+    entity_id: binary_sensor.rain_gauge
+    state: "off"
+    type: count
+    start: "{{ now().replace(month=1, day=1, hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+
+template:
+  - sensor:
+      - name: Rainfall [week]
+        unique_id: rainfall_week
+        state_class: measurement
+        unit_of_measurement: mm
+        icon: mdi:weather-pouring
+        state: >-
+          {% set on = states('sensor.rain_gauge_flips_on_week') | int(0) %}
+          {% set off = states('sensor.rain_gauge_flips_off_week') | int(0) %}
+          {% set mm = (on + off) * 0.31569 %}
+          {% if mm >= 0 %}
+            {{ mm | round(1, 'floor') }}
+          {% endif %}
+      - name: Rainfall [month]
+        unique_id: rainfall_month
+        state_class: measurement
+        unit_of_measurement: mm
+        icon: mdi:weather-pouring
+        state: >-
+          {% set on = states('sensor.rain_gauge_flips_on_month') | int(0) %}
+          {% set off = states('sensor.rain_gauge_flips_off_month') | int(0) %}
+          {% set mm = (on + off) * 0.31569 %}
+          {% if mm >= 0 %}
+            {{ mm | round(1, 'floor') }}
+          {% endif %}
+      - name: Rainfall [year]
+        unique_id: rainfall_year
+        state_class: measurement
+        unit_of_measurement: mm
+        icon: mdi:weather-pouring
+        state: >-
+          {% set on = states('sensor.rain_gauge_flips_on_year') | int(0) %}
+          {% set off = states('sensor.rain_gauge_flips_off_year') | int(0) %}
+          {% set mm = (on + off) * 0.31569 %}
+          {% if mm >= 0 %}
+            {{ mm | round(1, 'floor') }}
+          {% endif %}

--- a/rain-gauge/month-chart.yaml
+++ b/rain-gauge/month-chart.yaml
@@ -1,0 +1,26 @@
+---
+#
+# Monthly rain chart with previous year comparison.
+#
+
+type: custom:apexcharts-card
+header:
+  show: true
+  title: Monthly Rainfall
+graph_span: 1y
+span:
+  start: month
+series:
+  - entity: sensor.rainfall_month
+    name: This Year
+    type: column
+    group_by:
+      duration: 1month
+      func: max
+  - entity: sensor.rainfall_month
+    name: Last Year
+    type: column
+    offset: -1y
+    group_by:
+      duration: 1month
+      func: max

--- a/rain-gauge/week-chart.yaml
+++ b/rain-gauge/week-chart.yaml
@@ -1,0 +1,31 @@
+---
+#
+# Added to a dashboard to create a weekly chart of rain.
+#
+
+type: custom:mini-graph-card
+icon: mdi:weather-rainy
+name: Rain (weekly)
+aggregate_func: max
+hours_to_show: 1344  # 8 weeks
+group_by: week
+show:
+  graph: bar
+  fill: true
+  icon: false
+color_thresholds:
+  - value: 60
+    color: "#030ffc"
+  - value: 40
+    color: "#353ffc"
+  - value: 30
+    color: "#656dfc"
+  - value: 20
+    color: "#979dfc"
+  - value: 10
+    color: "#afb3fa"
+  - value: 0
+    color: "#ffffff"
+entities:
+  - entity: sensor.rainfall_week
+    state_adaptive_color: false

--- a/rain-gauge/year-progress-chart.yaml
+++ b/rain-gauge/year-progress-chart.yaml
@@ -1,0 +1,26 @@
+---
+#
+# Cumulative rainfall for the current year with last year comparison.
+#
+
+type: custom:apexcharts-card
+header:
+  show: true
+  title: Cumulative Rainfall (Year)
+graph_span: 1y
+span:
+  start: year
+series:
+  - entity: sensor.rainfall_year
+    name: This Year
+    type: line
+    group_by:
+      duration: 1day
+      func: last
+  - entity: sensor.rainfall_year
+    name: Last Year
+    type: line
+    offset: -1y
+    group_by:
+      duration: 1day
+      func: last


### PR DESCRIPTION
## Summary
- add weekly, monthly, and yearly cumulative rain sensors
- provide weekly, monthly, and year-progress charts

## Testing
- `yamllint rain-gauge/extended-configuration.yaml rain-gauge/week-chart.yaml rain-gauge/month-chart.yaml rain-gauge/year-progress-chart.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68c0c03c3150832bb6a8b7015228e507