### PR TITLE
Add hourly rainfall sensors and charts

### DIFF
--- a/packages/rain_gauge.yaml
+++ b/packages/rain_gauge.yaml
@@ -1,9 +1,10 @@
+---
 #
 # This gets added to configuration.yaml in Home Assistant.
 #
-
 #
-# Defines a sensor that caluculates counts of toggles of the rain_gauge (zigbee door sensor)
+# Defines a sensor that caluculates counts of toggles of the
+# rain_gauge (zigbee door sensor)
 #
 
 sensor:
@@ -23,15 +24,31 @@ sensor:
     type: count
     start: "{{ now() - timedelta(hours=24)}}"
     end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_on_hour
+    name: "Rain Gauge flips/on [hour]"
+    entity_id: binary_sensor.rain_gauge
+    state: "on"
+    type: count
+    start: "{{ now() - timedelta(hours=1)}}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    unique_id: rain_gauge_flips_off_hour
+    name: "Rain Gauge flips/off [hour]"
+    entity_id: binary_sensor.rain_gauge
+    state: "off"
+    type: count
+    start: "{{ now() - timedelta(hours=1)}}"
+    end: "{{ now() }}"
 
- #
- # Defines a template sensor that uses the flips caluculated above
- # creates a daily measurement.
- #
- #
+#
+# Defines template sensors that use the flips caluculated above.
+# Creates hourly and daily measurements.
+#
+#
 
-template:  
- 
+template:
+
   - sensor:
       - name: Rainfall [day]
         state_class: measurement
@@ -39,8 +56,21 @@ template:
         unit_of_measurement: mm
         icon: mdi:weather-pouring
         state: >-
-          {% set count = (states('sensor.rain_gauge_flips_on') | int(0)) + (states('sensor.rain_gauge_flips_off') | int(0)) %}
+          {% set count = (states('sensor.rain_gauge_flips_on') | int(0)) +
+                          (states('sensor.rain_gauge_flips_off') | int(0)) %}
           {% set mm = count * 0.31569 %}
           {% if count >= 0 %}
             {{ mm|round(1, 'floor') }}
+          {% endif %}
+      - name: Rainfall per hour
+        state_class: measurement
+        unique_id: rainfall_per_hour
+        unit_of_measurement: mm
+        icon: mdi:weather-pouring
+        state: >-
+          {% set on = states('sensor.rain_gauge_flips_on_hour') | int(0) %}
+          {% set off = states('sensor.rain_gauge_flips_off_hour') | int(0) %}
+          {% set mm = (on + off) * 0.31569 %}
+          {% if mm >= 0 %}
+            {{ mm | round(1, 'floor') }}
           {% endif %}

--- a/rain_gauge_charts/hour-chart-apex.yaml
+++ b/rain_gauge_charts/hour-chart-apex.yaml
@@ -1,0 +1,32 @@
+---
+#
+# Added to a dashboard to create an hourly chart of rain using ApexCharts.
+#
+
+type: custom:apexcharts-card
+header:
+  show: true
+  title: Hourly Rainfall
+graph_span: 2d
+span:
+  start: hour
+series:
+  - entity: sensor.rainfall_per_hour
+    name: Rain
+    type: column
+    group_by:
+      duration: 1h
+      func: max
+    color_threshold:
+      - value: 0
+        color: "#ffffff"
+      - value: 1
+        color: "#afb3fa"
+      - value: 3
+        color: "#979dfc"
+      - value: 5
+        color: "#656dfc"
+      - value: 7
+        color: "#353ffc"
+      - value: 12
+        color: "#030ffc"

--- a/rain_gauge_charts/hour-chart.yaml
+++ b/rain_gauge_charts/hour-chart.yaml
@@ -1,0 +1,31 @@
+---
+#
+# Added to a dashboard to create an hourly chart of rain.
+#
+
+type: custom:mini-graph-card
+icon: mdi:weather-rainy
+name: Rain (hourly)
+aggregate_func: max
+hours_to_show: 48
+group_by: hour
+show:
+  graph: bar
+  fill: true
+  icon: false
+color_thresholds:
+  - value: 12
+    color: "#030ffc"
+  - value: 7
+    color: "#353ffc"
+  - value: 5
+    color: "#656dfc"
+  - value: 3
+    color: "#979dfc"
+  - value: 1
+    color: "#afb3fa"
+  - value: 0
+    color: "#ffffff"
+entities:
+  - entity: sensor.rainfall_per_hour
+    state_adaptive_color: false


### PR DESCRIPTION
## Summary
- compute hourly rainfall from rain gauge flips
- add two-day hourly rainfall mini-graph and ApexCharts configurations

## Testing
- `yamllint packages/rain_gauge.yaml rain_gauge_charts/hour-chart.yaml rain_gauge_charts/hour-chart-apex.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68c156d1f924832bbe1ab9f52d5a3377